### PR TITLE
Update lilypad_module.json.tmpl

### DIFF
--- a/lilypad_module.json.tmpl
+++ b/lilypad_module.json.tmpl
@@ -2,7 +2,7 @@
     "machine": {
         "gpu": 0,
         "cpu": 1000,
-        "ram": 4000
+        "ram": 6000
     },
     "job": {
         "APIVersion": "V1beta1",


### PR DESCRIPTION
Minimum ram requirement for Bacalhau has been changed to 6Mb or 6000